### PR TITLE
Update for ctypes 0.5.

### DIFF
--- a/lib/passwd.ml
+++ b/lib/passwd.ml
@@ -27,13 +27,13 @@ type passwd_t
 
 let passwd_t : passwd_t structure typ = structure "passwd"
 
-let pw_name   = passwd_t *:* string
-let pw_passwd = passwd_t *:* string
-let pw_uid    = passwd_t *:* int
-let pw_gid    = passwd_t *:* int
-let pw_gecos  = passwd_t *:* string
-let pw_dir    = passwd_t *:* string
-let pw_shell  = passwd_t *:* string
+let pw_name   = field passwd_t "pw_name" string
+let pw_passwd = field passwd_t "pw_passwd" string
+let pw_uid    = field passwd_t "pw_uid" int
+let pw_gid    = field passwd_t "pw_gid" int
+let pw_gecos  = field passwd_t "pw_gecos" string
+let pw_dir    = field passwd_t "pw_dir" string
+let pw_shell  = field passwd_t "pw_shell" string
 
 let () = seal passwd_t
 

--- a/lib/shadow.ml
+++ b/lib/shadow.ml
@@ -20,15 +20,15 @@ type shadow_t
 
 let shadow_t : shadow_t structure typ = structure "passwd"
 
-let sp_name     = shadow_t *:* string
-let sp_passwd   = shadow_t *:* string
-let sp_last_chg = shadow_t *:* long
-let sp_min      = shadow_t *:* long
-let sp_max      = shadow_t *:* long
-let sp_warn     = shadow_t *:* long
-let sp_inact    = shadow_t *:* long
-let sp_expire   = shadow_t *:* long
-let sp_flag     = shadow_t *:* ulong
+let sp_name     = field shadow_t "sp_name" string
+let sp_passwd   = field shadow_t "sp_passwd" string
+let sp_last_chg = field shadow_t "sp_last_chg" long
+let sp_min      = field shadow_t "sp_min" long
+let sp_max      = field shadow_t "sp_max" long
+let sp_warn     = field shadow_t "sp_warn" long
+let sp_inact    = field shadow_t "sp_inact" long
+let sp_expire   = field shadow_t "sp_expire" long
+let sp_flag     = field shadow_t "sp_flag" ulong
 
 let () = seal shadow_t
 


### PR DESCRIPTION
The `*:*` operator is no longer available in recent releases of ctypes.  This PR changes the code to use [field](http://ocamllabs.github.io/ocaml-ctypes/Ctypes_types.TYPE.html#VALfield) instead.