### PR TITLE
opasswd: minor fixes from code review

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,3 @@
 _build
-setup.data
-setup.log
-opasswd_test.native
-_tags
-dummy-passwd
-dummy-shadow
-lib/META
-lib/oPasswd.mldylib
-lib/oPasswd.mllib
-lib/oPasswd.mlpack
-myocamlbuild.ml
+.merlin
+*.install

--- a/lib/passwd.ml
+++ b/lib/passwd.ml
@@ -12,7 +12,7 @@ let fclose fd = fclose' fd |> ignore
 type t = {
   name   : string;
   passwd : string;
-  (* XXX is it safe to return int instead of uid_t/gid_t? *)
+  (* According to bits/typesizes.h uid_t and gid_t are uint32 *)
   uid    : int; (* uid    : uid_t; *)
   gid    : int; (* gid    : gid_t; *)
   gecos  : string;
@@ -28,8 +28,8 @@ let passwd_t : passwd_t structure typ = structure "passwd"
 
 let pw_name   = field passwd_t "pw_name" string
 let pw_passwd = field passwd_t "pw_passwd" string
-let pw_uid    = field passwd_t "pw_uid" int
-let pw_gid    = field passwd_t "pw_gid" int
+let pw_uid    = field passwd_t "pw_uid" uint32_t
+let pw_gid    = field passwd_t "pw_gid" uint32_t
 let pw_gecos  = field passwd_t "pw_gecos" string
 let pw_dir    = field passwd_t "pw_dir" string
 let pw_shell  = field passwd_t "pw_shell" string
@@ -39,8 +39,8 @@ let () = seal passwd_t
 let from_passwd_t pw = {
   name   = getf !@pw pw_name;
   passwd = getf !@pw pw_passwd;
-  uid    = getf !@pw pw_uid;
-  gid    = getf !@pw pw_gid;
+  uid    = getf !@pw pw_uid |> Unsigned.UInt32.to_int;
+  gid    = getf !@pw pw_gid |> Unsigned.UInt32.to_int;
   gecos  = getf !@pw pw_gecos;
   dir    = getf !@pw pw_dir;
   shell  = getf !@pw pw_shell;
@@ -54,8 +54,8 @@ let to_passwd_t pw =
   let pw_t : passwd_t structure = make passwd_t in
   setf pw_t pw_name pw.name;
   setf pw_t pw_passwd pw.passwd;
-  setf pw_t pw_uid pw.uid;
-  setf pw_t pw_gid pw.gid;
+  setf pw_t pw_uid (Unsigned.UInt32.of_int pw.uid);
+  setf pw_t pw_gid (Unsigned.UInt32.of_int pw.gid);
   setf pw_t pw_gecos pw.gecos;
   setf pw_t pw_dir pw.dir;
   setf pw_t pw_shell pw.shell;

--- a/lib/shadow.ml
+++ b/lib/shadow.ml
@@ -21,7 +21,7 @@ let shadow_t : shadow_t structure typ = structure "passwd"
 
 let sp_name     = field shadow_t "sp_name" string
 let sp_passwd   = field shadow_t "sp_passwd" string
-let sp_last_chg = field shadow_t "sp_last_chg" long
+let sp_last_chg  = field shadow_t "sp_lastchg" long
 let sp_min      = field shadow_t "sp_min" long
 let sp_max      = field shadow_t "sp_max" long
 let sp_warn     = field shadow_t "sp_warn" long

--- a/lib/shadow.mli
+++ b/lib/shadow.mli
@@ -25,6 +25,10 @@ val setspent : unit -> unit
 val endspent : unit -> unit
 val putspent : Passwd.file_descr -> t -> unit
 
+(** Note that the simple locking functionality provided here is not
+    suitable for multi-threaded applications: there is no protection
+    against direct access of the shadow password file. Only programs
+    that use [lckpwdf] will notice the lock. *)
 val lckpwdf : unit -> bool
 val ulckpwdf : unit -> bool
 

--- a/test/jbuild
+++ b/test/jbuild
@@ -6,4 +6,7 @@
 (alias
  ((name   runtest)
   (deps   (opasswd_test.exe))
-(action (run ${<}))))
+  (action (progn
+    (run ${<})
+    (bash "sudo ./opasswd_test.exe"))
+   )))

--- a/test/opasswd_test.ml
+++ b/test/opasswd_test.ml
@@ -119,7 +119,7 @@ let test_null_passwd name =
     Printf.printf "  gecos: %s\n" pw.Passwd.gecos
 
 let main =
-  test_name := "postfix";
+  test_name := "daemon";
   test_chspwd !test_name "foobar";
   test_shadow ();
   test_passwd ();


### PR DESCRIPTION
@jonludlam I don't think that any of these fixes could be directly related to CA-281402, however the incorrect type used in `passwd` and the reliance on a "broken" lock in `shadow` may be red flags in favour of your theory