### PR TITLE
CA-281402: Update string fields to char ptrs

### DIFF
--- a/lib/passwd.ml
+++ b/lib/passwd.ml
@@ -36,11 +36,7 @@ let pw_shell  = field passwd_t "pw_shell" (ptr char)
 
 let () = seal passwd_t
 
-let ptr_char_to_string p =
-  let s = coerce (ptr char) string p in
-  let b = Buffer.create 128 in
-  Buffer.add_string b s;
-  Buffer.contents b
+let ptr_char_to_string p = coerce (ptr char) string p
 
 let string_to_char_array s =
   let len = String.length s in

--- a/lib/passwd.ml
+++ b/lib/passwd.ml
@@ -88,7 +88,9 @@ let endpwent = foreign ~check_errno:true "endpwent" (void @-> returning void)
 
 let putpwent' =
   foreign ~check_errno:true "putpwent" (ptr passwd_t @-> file_descr @-> returning int)
-let putpwent fd pw = putpwent' (to_passwd_t pw |> addr) fd |> ignore
+let putpwent fd pw =
+  let passwd_ptr = addr (to_passwd_t pw) in
+  putpwent' passwd_ptr fd |> ignore
 
 let get_db () =
   let rec loop acc =

--- a/lib/shadow.ml
+++ b/lib/shadow.ml
@@ -19,8 +19,8 @@ type shadow_t
 
 let shadow_t : shadow_t structure typ = structure "passwd"
 
-let sp_name     = field shadow_t "sp_name" string
-let sp_passwd   = field shadow_t "sp_passwd" string
+let sp_name     = field shadow_t "sp_name" (ptr char)
+let sp_passwd   = field shadow_t "sp_passwd" (ptr char)
 let sp_last_chg  = field shadow_t "sp_lastchg" long
 let sp_min      = field shadow_t "sp_min" long
 let sp_max      = field shadow_t "sp_max" long
@@ -31,9 +31,21 @@ let sp_flag     = field shadow_t "sp_flag" ulong
 
 let () = seal shadow_t
 
+let ptr_char_to_string p =
+  let s = coerce (ptr char) string p in
+  let b = Buffer.create 128 in
+  Buffer.add_string b s;
+  Buffer.contents b
+
+let string_to_char_array s =
+  let len = String.length s in
+  let buf = CArray.make char ~initial:'\x00' len in
+  String.iteri (fun idx c -> CArray.set buf idx c) s;
+  buf
+
 let from_shadow_t sp = {
-  name     = getf !@sp sp_name;
-  passwd   = getf !@sp sp_passwd;
+  name     = getf !@sp sp_name |> ptr_char_to_string;
+  passwd   = getf !@sp sp_passwd |> ptr_char_to_string;
   last_chg = getf !@sp sp_last_chg |> Signed.Long.to_int64;
   min      = getf !@sp sp_min |> Signed.Long.to_int64;
   max      = getf !@sp sp_max |> Signed.Long.to_int64;
@@ -49,8 +61,8 @@ let from_shadow_t_opt = function
 
 let to_shadow_t sp =
   let sp_t : shadow_t structure = make shadow_t in
-  setf sp_t sp_name sp.name;
-  setf sp_t sp_passwd sp.passwd;
+  setf sp_t sp_name (sp.name |> string_to_char_array |> CArray.start);
+  setf sp_t sp_passwd (sp.passwd |> string_to_char_array |> CArray.start);
   setf sp_t sp_last_chg (Signed.Long.of_int64 sp.last_chg);
   setf sp_t sp_min (Signed.Long.of_int64 sp.min);
   setf sp_t sp_max (Signed.Long.of_int64 sp.max);

--- a/lib/shadow.ml
+++ b/lib/shadow.ml
@@ -31,11 +31,7 @@ let sp_flag     = field shadow_t "sp_flag" ulong
 
 let () = seal shadow_t
 
-let ptr_char_to_string p =
-  let s = coerce (ptr char) string p in
-  let b = Buffer.create 128 in
-  Buffer.add_string b s;
-  Buffer.contents b
+let ptr_char_to_string = coerce (ptr char) string
 
 let string_to_char_array s =
   let len = String.length s in

--- a/lib/shadow.ml
+++ b/lib/shadow.ml
@@ -84,7 +84,9 @@ let endspent = foreign ~check_errno:true "endspent" (void @-> returning void)
 let putspent' =
   foreign ~check_errno:true
     "putspent" (ptr shadow_t @-> Passwd.file_descr @-> returning int)
-let putspent fd sp = putspent' (to_shadow_t sp |> addr) fd |> ignore
+let putspent fd sp = 
+  let shadow_ptr = addr (to_shadow_t sp) in
+  putspent' shadow_ptr fd |> ignore
 
 let lckpwdf' = foreign "lckpwdf" (void @-> returning int)
 let lckpwdf () = lckpwdf' () = 0

--- a/opasswd.opam
+++ b/opasswd.opam
@@ -13,4 +13,4 @@ depends: [
   "ctypes-foreign"
 ]
 tags: [ "org:xapi-project" ]
-available: [ ocaml-version >= "4.01.0" & ocaml-version <= "4.06.0" ]
+available: [ ocaml-version >= "4.01.0" & ocaml-version <= "4.07.0" ]


### PR DESCRIPTION
From the mailing list discussion:

> When the memory is owned by C code -- for example, when a C function
  passes a struct to OCaml with fields already initialized -- then using
  the string view works well: reading a string field creates an OCaml
  copy, which persists as long as needed.

> However, when things are the other way round -- i.e. when you're
  creating or initializing the struct in OCaml before passing it to C --
  then the string view isn't a good choice, because there's no way to
  manage the lifetime of the C copy of the OCaml string that's written
  to the struct field.

> A reasonable way to do this would be to allocate stable memory for the
  string fields before the C call, and ensure that the memory stays
  around until the call is complete.  Stable memory could mean any of: a
  bigarray, a Ctypes.CArray.t value, memory returned by malloc, memory
  returned by Ctypes.allocate, etc.  In most of these cases ensuring the
  memory stays around is a matter of holding onto the handle (bigarray
  value, Ctypes ptr, etc.) until after the call.

This PR is to remove the string view and use the char ptrs instead.
The tricky parts are:

- extracting the string as we don't know the lenght, and
- making them live long enough

The lifetimes after copy should now be fine, after the improvements suggested by @edwintorok.
The string casting has been fiurther simplified, thanks @lindig, and we agree that we need to rely on the c library to return well formed memory there. 

------

Initially I did the following

```ocaml
(* We can't define it as
   CArray.(string_from_ptr (start a) (length a))
   as we do not know the length of the string a priori.

   Will fail with `Invalid_argument "index_out_of_bounds" if
   we don't reach the null terminator by [maxlen] chars.
*)
let char_array_as_string ?(maxlen=1024) a =
  (* here we overflow but we should never read after the string if the
     memory is not corrupted *)
  let a': char carray = CArray.from_ptr a maxlen in
  let b = Buffer.create 128 in
  let rec scan idx =
    let c = CArray.get a' idx in
    if c = '\x00' then
      Buffer.contents b
    else begin
      Buffer.add_char b c;
      scan (idx+1)
    end
  in
  scan 0
```

But I think that the above is morally equivalent to the current

```ocaml
let ptr_char_to_string p =
  let s = coerce (ptr char) string p in
  let b = Buffer.create 128 in
  Buffer.add_string b s;
  Buffer.contents b
```

although more explicit. In both cases we risk to do an overflow and
fail. It could be that the original is better as we fail more explicitly
while here we are somewhat hoping for the best. Either way, we are
strongly relying on the C strings to be null terminated and the memory
to be sane.

Signed-off-by: Marcello Seri <marcello.seri@citrix.com>