### PR TITLE
Memory safety

### DIFF
--- a/lib/passwd.ml
+++ b/lib/passwd.ml
@@ -45,18 +45,18 @@ let string_to_char_array s =
   buf
 
 let from_passwd_t pw = {
-  name   = getf !@pw pw_name |> ptr_char_to_string;
-  passwd = getf !@pw pw_passwd |> ptr_char_to_string;
-  uid    = getf !@pw pw_uid |> Unsigned.UInt32.to_int;
-  gid    = getf !@pw pw_gid |> Unsigned.UInt32.to_int;
-  gecos  = getf !@pw pw_gecos |> ptr_char_to_string;
-  dir    = getf !@pw pw_dir |> ptr_char_to_string;
-  shell  = getf !@pw pw_shell |> ptr_char_to_string;
+  name   = getf pw pw_name |> ptr_char_to_string;
+  passwd = getf pw pw_passwd |> ptr_char_to_string;
+  uid    = getf pw pw_uid |> Unsigned.UInt32.to_int;
+  gid    = getf pw pw_gid |> Unsigned.UInt32.to_int;
+  gecos  = getf pw pw_gecos |> ptr_char_to_string;
+  dir    = getf pw pw_dir |> ptr_char_to_string;
+  shell  = getf pw pw_shell |> ptr_char_to_string;
 }
 
 let from_passwd_t_opt = function
   | None -> None
-  | Some pw -> Some (from_passwd_t pw)
+  | Some pw -> Some (from_passwd_t !@pw)
 
 let to_passwd_t pw =
   let pw_t : passwd_t structure = make passwd_t in

--- a/lib/passwd.ml
+++ b/lib/passwd.ml
@@ -58,16 +58,31 @@ let from_passwd_t_opt = function
   | None -> None
   | Some pw -> Some (from_passwd_t !@pw)
 
-let to_passwd_t pw =
-  let pw_t : passwd_t structure = make passwd_t in
-  setf pw_t pw_name (pw.name |> string_to_char_array |> CArray.start);
-  setf pw_t pw_passwd (pw.passwd |> string_to_char_array |> CArray.start);
-  setf pw_t pw_uid (Unsigned.UInt32.of_int pw.uid);
-  setf pw_t pw_gid (Unsigned.UInt32.of_int pw.gid);
-  setf pw_t pw_gecos (pw.gecos |> string_to_char_array |> CArray.start);
-  setf pw_t pw_dir (pw.dir |> string_to_char_array |> CArray.start);
-  setf pw_t pw_shell (pw.shell |> string_to_char_array |> CArray.start);
-  pw_t
+module Mem : sig
+  type mem
+  val to_mem : t -> mem
+  val passwd_addr_of_mem : mem -> (passwd_t, [`Struct]) Ctypes.structured Ctypes.ptr
+end = struct
+  type mem = passwd_t structure * char carray * char carray * char carray * char carray * char carray
+
+  let to_mem pw =
+    let name = string_to_char_array pw.name in
+    let passwd = string_to_char_array pw.passwd in
+    let gecos = string_to_char_array pw.gecos in
+    let dir = string_to_char_array pw.dir in
+    let shell = string_to_char_array pw.shell in
+    let pw_t : passwd_t structure = make passwd_t in
+    setf pw_t pw_name (CArray.start name);
+    setf pw_t pw_passwd (CArray.start passwd);
+    setf pw_t pw_uid (Unsigned.UInt32.of_int pw.uid);
+    setf pw_t pw_gid (Unsigned.UInt32.of_int pw.gid);
+    setf pw_t pw_gecos (CArray.start gecos);
+    setf pw_t pw_dir (CArray.start dir);
+    setf pw_t pw_shell (CArray.start shell);
+    (pw_t, name, passwd, gecos, dir, shell)
+
+  let passwd_addr_of_mem (sp_t, _, _, _, _, _) = addr sp_t
+end
 
 let passwd_file = "/etc/passwd"
 
@@ -89,8 +104,8 @@ let endpwent = foreign ~check_errno:true "endpwent" (void @-> returning void)
 let putpwent' =
   foreign ~check_errno:true "putpwent" (ptr passwd_t @-> file_descr @-> returning int)
 let putpwent fd pw =
-  let passwd_ptr = addr (to_passwd_t pw) in
-  putpwent' passwd_ptr fd |> ignore
+  let mem = Mem.to_mem pw in
+  putpwent' (Mem.passwd_addr_of_mem mem) fd |> ignore
 
 let get_db () =
   let rec loop acc =

--- a/lib/shadow.ml
+++ b/lib/shadow.ml
@@ -40,20 +40,20 @@ let string_to_char_array s =
   buf
 
 let from_shadow_t sp = {
-  name     = getf !@sp sp_name |> ptr_char_to_string;
-  passwd   = getf !@sp sp_passwd |> ptr_char_to_string;
-  last_chg = getf !@sp sp_last_chg |> Signed.Long.to_int64;
-  min      = getf !@sp sp_min |> Signed.Long.to_int64;
-  max      = getf !@sp sp_max |> Signed.Long.to_int64;
-  warn     = getf !@sp sp_warn |> Signed.Long.to_int64;
-  inact    = getf !@sp sp_inact |> Signed.Long.to_int64;
-  expire   = getf !@sp sp_expire |> Signed.Long.to_int64;
-  flag     = getf !@sp sp_flag |> Unsigned.ULong.to_int;
+  name     = getf sp sp_name |> ptr_char_to_string;
+  passwd   = getf sp sp_passwd |> ptr_char_to_string;
+  last_chg = getf sp sp_last_chg |> Signed.Long.to_int64;
+  min      = getf sp sp_min |> Signed.Long.to_int64;
+  max      = getf sp sp_max |> Signed.Long.to_int64;
+  warn     = getf sp sp_warn |> Signed.Long.to_int64;
+  inact    = getf sp sp_inact |> Signed.Long.to_int64;
+  expire   = getf sp sp_expire |> Signed.Long.to_int64;
+  flag     = getf sp sp_flag |> Unsigned.ULong.to_int;
 }
 
 let from_shadow_t_opt = function
   | None -> None
-  | Some sp -> Some (from_shadow_t sp)
+  | Some sp -> Some (from_shadow_t !@sp)
 
 let to_shadow_t sp =
   let sp_t : shadow_t structure = make shadow_t in

--- a/lib/shadow.ml
+++ b/lib/shadow.ml
@@ -55,18 +55,41 @@ let from_shadow_t_opt = function
   | None -> None
   | Some sp -> Some (from_shadow_t !@sp)
 
-let to_shadow_t sp =
-  let sp_t : shadow_t structure = make shadow_t in
-  setf sp_t sp_name (sp.name |> string_to_char_array |> CArray.start);
-  setf sp_t sp_passwd (sp.passwd |> string_to_char_array |> CArray.start);
-  setf sp_t sp_last_chg (Signed.Long.of_int64 sp.last_chg);
-  setf sp_t sp_min (Signed.Long.of_int64 sp.min);
-  setf sp_t sp_max (Signed.Long.of_int64 sp.max);
-  setf sp_t sp_warn (Signed.Long.of_int64 sp.warn);
-  setf sp_t sp_inact (Signed.Long.of_int64 sp.inact);
-  setf sp_t sp_expire (Signed.Long.of_int64 sp.expire);
-  setf sp_t sp_flag (Unsigned.ULong.of_int sp.flag);
-  sp_t
+(* Wrap up all the allocating functions into this module that
+   returns an opaque type. This tries to make sure that the
+   lifetime of all the allocated memory is the same. The one
+   dangerous thing is 'shadow_addr_of_mem' - but it's a bit
+   more obvious that you've got to keep the 'mem' value alive
+   than the individual fields within it too. Note that we
+   actually hide `shadow_addr_of_mem` from outside this module
+   via the mli file. Paranoia! *)
+module Mem : sig
+  type mem
+  val to_mem : t -> mem
+  val from_mem : mem -> t
+  val shadow_addr_of_mem : mem -> (shadow_t, [ `Struct ]) Ctypes.structured Ctypes.ptr
+end = struct
+  type mem = shadow_t structure * char carray * char carray
+
+  let to_mem sp =
+    let name = string_to_char_array sp.name in
+    let passwd = string_to_char_array sp.passwd in
+    let sp_t : shadow_t structure = make shadow_t in
+    setf sp_t sp_name (CArray.start name);
+    setf sp_t sp_passwd (CArray.start passwd);
+    setf sp_t sp_last_chg (Signed.Long.of_int64 sp.last_chg);
+    setf sp_t sp_min (Signed.Long.of_int64 sp.min);
+    setf sp_t sp_max (Signed.Long.of_int64 sp.max);
+    setf sp_t sp_warn (Signed.Long.of_int64 sp.warn);
+    setf sp_t sp_inact (Signed.Long.of_int64 sp.inact);
+    setf sp_t sp_expire (Signed.Long.of_int64 sp.expire);
+    setf sp_t sp_flag (Unsigned.ULong.of_int sp.flag);
+    (sp_t,name,passwd)
+
+  let from_mem (sp_t, _name, _passwd) = from_shadow_t sp_t
+
+  let shadow_addr_of_mem (sp_t, _, _) = addr sp_t
+end
 
 let shadow_file = "/etc/shadow"
 
@@ -84,9 +107,9 @@ let endspent = foreign ~check_errno:true "endspent" (void @-> returning void)
 let putspent' =
   foreign ~check_errno:true
     "putspent" (ptr shadow_t @-> Passwd.file_descr @-> returning int)
-let putspent fd sp = 
-  let shadow_ptr = addr (to_shadow_t sp) in
-  putspent' shadow_ptr fd |> ignore
+let putspent fd sp =
+  let mem = Mem.to_mem sp in
+  putspent' (Mem.shadow_addr_of_mem mem) fd |> ignore
 
 let lckpwdf' = foreign "lckpwdf" (void @-> returning int)
 let lckpwdf () = lckpwdf' () = 0

--- a/lib/shadow.mli
+++ b/lib/shadow.mli
@@ -16,6 +16,13 @@ val to_string : t -> string
 
 type db = t list
 
+type shadow_t
+
+val shadow_t : shadow_t Ctypes_static.structure Ctypes.typ
+
+val from_shadow_t : shadow_t Ctypes.structure -> t
+val to_shadow_t : t -> shadow_t Ctypes.structure
+
 val db_to_string : db -> string
 
 val getspnam : string -> t option

--- a/lib/shadow.mli
+++ b/lib/shadow.mli
@@ -16,12 +16,12 @@ val to_string : t -> string
 
 type db = t list
 
-type shadow_t
+module Mem : sig
+  type mem
 
-val shadow_t : shadow_t Ctypes_static.structure Ctypes.typ
-
-val from_shadow_t : shadow_t Ctypes.structure -> t
-val to_shadow_t : t -> shadow_t Ctypes.structure
+  val to_mem : t -> mem
+  val from_mem : mem -> t
+end
 
 val db_to_string : db -> string
 

--- a/test/opasswd_test.ml
+++ b/test/opasswd_test.ml
@@ -81,7 +81,7 @@ let test_gc () =
   let rec mkshadow n =
     let name = "myname" in
     let passwd = "mypasswd" in
-    let tmp = Shadow.(to_shadow_t {name; passwd; last_chg=0L; min=0L; max=0L; warn=0L; inact=0L; expire=0L; flag=0;}) in
+    let tmp = Shadow.(Mem.to_mem {name; passwd; last_chg=0L; min=0L; max=0L; warn=0L; inact=0L; expire=0L; flag=0;}) in
     if n=0
     then tmp
     else begin
@@ -92,8 +92,8 @@ let test_gc () =
   in
   let first = mkshadow 10000 in
   let second = mkshadow 10000 in
-  let first_t = Shadow.from_shadow_t first in
-  let second_t = Shadow.from_shadow_t second in
+  let first_t = Shadow.Mem.from_mem first in
+  let second_t = Shadow.Mem.from_mem second in
   if (first_t = second_t) then
     Printf.printf "shadow OK!\n%!"
   else begin

--- a/test/opasswd_test.ml
+++ b/test/opasswd_test.ml
@@ -77,31 +77,30 @@ let test_unshadow () =
 
 (* Try to blow up GC *)
 let test_gc () =
-  let name = !test_name
-  and iter = 1000000 in
+  Printf.printf "Testing shadow\n%!";
+  let rec mkshadow n =
+    let name = "myname" in
+    let passwd = "mypasswd" in
+    let tmp = Shadow.(to_shadow_t {name; passwd; last_chg=0L; min=0L; max=0L; warn=0L; inact=0L; expire=0L; flag=0;}) in
+    if n=0
+    then tmp
+    else begin
+      let result = mkshadow (n-1) in
+      if name=passwd then failwith "ugh";
+      result;
+    end
+  in
+  let first = mkshadow 10000 in
+  let second = mkshadow 10000 in
+  let first_t = Shadow.from_shadow_t first in
+  let second_t = Shadow.from_shadow_t second in
+  if (first_t = second_t) then
+    Printf.printf "shadow OK!\n%!"
+  else begin
+    Printf.printf "Not OK: '%s' '%s'\n%!" (Shadow.to_string first_t) (Shadow.to_string second_t);
+    failwith "Not memory safe!"
+  end
 
-  (* Lower GC heap sizes, set verbose *)
-  (* Gc.set { (Gc.get ()) with *)
-  (*   Gc.verbose = 0x3FF; *)
-  (*   Gc.minor_heap_size = 1; *)
-  (* }; *)
-
-  Printf.printf "Testing Passwd.getpwnam on %d iterations\n" iter;
-  Pervasives.(flush stdout);
-  for i = 1 to iter do
-    ignore (Passwd.getpwnam name)
-  done;
-
-  Printf.printf "Testing Shadow.getspnam on %d iterations\n" iter;
-  begin
-    try
-      for i = 1 to iter do
-        ignore Shadow.(with_lock (fun () -> getspnam name))
-      done;
-    with _ ->
-      print_endline "Couldn't acquire lock, must be root";
-  end;
-  print_endline "* finished test_unshadow"; flush Pervasives.stdout
 
 let test_chspwd name pass =
   let open Shadow in


### PR DESCRIPTION
If we're allocating memory for use by c functions, we must make sure
that _all_ of the OCaml objects that are referencing the memory
live long enough. Particularly important, and what is fixed by this commit,
is that if you've got a structure with fields that are pointing at
allocated memory, it's not sufficient to keep the OCaml object that
references the structure alive - you _must_ keep all of the other
objects referncing the pointed-at memory in scope too - the GC isn't
omniscient!

The approach in this commit is to keep all the allocated objects together
in a tuple whose type is made opaque, and only provide accessors for
the values necessary (e.g. in this case, we need the address of the
structure).
